### PR TITLE
clean up header for mobile and set minimum page height based on viewport

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -90,18 +90,28 @@ header a[href]:visited {
 .nav {
   font-family: "Raleway", sans-serif;
   list-style: none;
-  display:table-row;
+  display: flex;
+  padding-left: 0;
+  align-items: center;
+  justify-content: start;
+  flex-wrap: wrap;
+  margin-top: 0;
 }
 .nav-item {
   padding: 1em 1.5em 0 1em;
-  display: table-cell;
-  vertical-align: middle;
+  display: block;
 }
 .home {
     padding-right: 2em;
 }
 .nav-item a {
   color: white;
+}
+
+/* Main */
+
+main {
+  min-height: 75vh;
 }
 
 /* Buttons */


### PR DESCRIPTION
Congratulations on the foundation!!!

The site looked a little funky on mobile and I figured out it was due to some header stuff- this is a change that converts the header to flexbox so it can wrap on narrower screen sizes.

I also put a minimum height on `<main>` so the footer doesn't float halfway up the screen on short pages.