### PR TITLE
improve contrast for nav link on hover not visited

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -107,6 +107,9 @@ header a[href]:visited {
 .nav-item a {
   color: white;
 }
+.nav-item a:hover {
+  color: var(--white)
+}
 
 /* Main */
 


### PR DESCRIPTION
## What does this change do?
This improves the **color contract** for the **hovering state of nav item links that have not been visited yet**, by changing the color to "white".
![grafik](https://user-images.githubusercontent.com/8432168/107285208-1d3e6d80-6a5f-11eb-9b30-3ba809a9359b.png)

## What is the current state and why do we need this?
Currently, the nav item links that are in hovering state and have not been visited yet have a color of "orange".
This orange color blends in with the background color in the header, which makes the nav item links hard to see.
![grafik](https://user-images.githubusercontent.com/8432168/107286173-81adfc80-6a60-11eb-931d-9f7472ca396d.png)

## Possible concerns/risks
There is another (new) selector that could be used:
```css
header a[href] {
  ...
}
```
Why is this highlighted? Because there is already a selector, which is for header links **:visited** (see [line 85](https://github.com/rust-lang/foundation.rust-lang.org/blob/8330295db9a0fa5725efc1ca8f3cabc4769639d5/css/index.css#L85)):
```css
header a[href]:visited {
  color: var(--lightgrey);
}
```
Keep in mind that currently "white" is also used, when the link is in **no** special state (e.g. :hover, :visited etc.).
This should not be a problem, due to the additional underline text decoration when hovered.
*In fact, **not changing color on hover on nav items** can also be seen at https://www.rust-lang.org/, although it's background color is white, so comparing the two might not be the best.*

Also, the color "white" on the orange background does **not** conform to the [Web Content Accessibility Guidelines in terms of minimum contrast](https://www.w3.org/TR/WCAG21/#contrast-minimum).

## Thank you
Thank you Rustaceans for forming this foundation! :heart: :crab: You are all probably very busy right now, so I hope I can help with this contribution even if it's small.
