### PR TITLE
Fix horizontal overflow + text flow on mobile

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,7 +73,7 @@ module.exports = function(eleventyConfig) {
   /* Markdown Overrides */
   let markdownLibrary = markdownIt({
     html: true,
-    breaks: true,
+    breaks: false,
     linkify: true
   }).use(markdownItAnchor, {
     permalink: true,

--- a/css/index.css
+++ b/css/index.css
@@ -368,6 +368,18 @@ footer .container {
   }
 }
 
+@media only screen and (max-width: 768px) {
+  /* prevent horizontal overflow of headings on mobile */
+  .post h2 {
+    font-size: 1.2em !important;
+  }
+
+  .post h1, .event h1, .posts h1, .events h1, .board h1, .contact h1, .members h1 {
+    font-size: 2em !important;
+    margin-top: 3em !important;
+  }
+}
+
 .post h1, .event h1, .posts h1, .events h1, .board h1, .contact h1, .members h1 {
   font-size: 5em;
   font-weight: 900;


### PR DESCRIPTION
Previously, post titles were causing horizontal scrolling on mobile
browsers as the screen was not wide enough to fit a single word in the
size used on desktop browsers.

I also fixed some funny business that was going on with text reflow,
which was caused by the line wrapped markdown source files getting the
line breaks at 72 characters turned into HTML line breaks, causing
weird breaking on screens not wide enough for a full line.